### PR TITLE
POC-156: Rename weirdly named variables

### DIFF
--- a/Assets/Prefabs/PlayerFox.prefab
+++ b/Assets/Prefabs/PlayerFox.prefab
@@ -322,34 +322,33 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 23ab3354648954851aa2118b29a80bf1, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  AirMoveSpeed: 5
-  MaxVelocityInputThreshold: 10
-  CoefficientCurve:
+  m_GroundMoveSpeed: 5
+  m_AirAcceleration: 3
+  m_MaxAirSpeed: 0
+  m_AirAccelerationCurve:
     serializedVersion: 2
     m_Curve:
     - serializedVersion: 3
       time: 0
-      value: -0.0014648438
-      inSlope: 3.2756915
-      outSlope: 3.2756915
+      value: 0
+      inSlope: 2
+      outSlope: 2
       tangentMode: 0
       weightedMode: 0
       inWeight: 0
-      outWeight: 0.019128725
+      outWeight: 0
     - serializedVersion: 3
       time: 1
       value: 1
-      inSlope: -0.07635334
-      outSlope: -0.07635334
+      inSlope: 0
+      outSlope: 0
       tangentMode: 0
       weightedMode: 0
-      inWeight: 0.03417808
+      inWeight: 0
       outWeight: 0
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 4
-  GroundMoveSpeed: 6.5
-  directionX: 0
 --- !u!114 &1208819179330828543
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -457,7 +456,6 @@ MonoBehaviour:
   m_StallTime: 2
   m_RevertVelocity: 1
   m_Cooldown: 5
-  m_CooldownTimer: 0
 --- !u!114 &3023190908246841861
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Levels/A.unity
+++ b/Assets/Scenes/Levels/A.unity
@@ -130,6 +130,14 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 474916487, guid: fea7d46b09dd64780ba611993068e295, type: 3}
+      propertyPath: m_MaxAirSpeed
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 474916487, guid: fea7d46b09dd64780ba611993068e295, type: 3}
+      propertyPath: m_MaxMoveSpeed
+      value: 10
+      objectReference: {fileID: 0}
     - target: {fileID: 107137074636933800, guid: fea7d46b09dd64780ba611993068e295,
         type: 3}
       propertyPath: m_RootOrder

--- a/Assets/Scripts/HorizontalMovement.cs
+++ b/Assets/Scripts/HorizontalMovement.cs
@@ -7,9 +7,13 @@ public class HorizontalMovement : MonoBehaviour
 
     [Tooltip("Speed of the player when in the air")]
     public float AirMoveSpeed = 3f;
-    public float MaxVelocityInputThreshold;
-    public AnimationCurve CoefficientCurve;
-    public float GroundMoveSpeed = 5;
+    [SerializeField]
+    private float MaxVelocityInputThreshold;
+    [SerializeField]
+    private AnimationCurve CoefficientCurve;
+    [SerializeField]
+    private float GroundMoveSpeed = 5;
+
     private Rigidbody2D rb;
     private float directionX;
     private Grounded m_Grounded;

--- a/Assets/Scripts/HorizontalMovement.cs
+++ b/Assets/Scripts/HorizontalMovement.cs
@@ -3,16 +3,24 @@ using UnityEngine.InputSystem;
 
 public class HorizontalMovement : MonoBehaviour
 {
-    [Tooltip("Speed of the player when in the air")]
+    [Header("Ground movement")]
+    [Tooltip("Fox's speed on the ground")]
     [SerializeField]
-    private float m_GroundMoveSpeed = 5f;
+    private float m_GroundSpeed = 5f;
+
+    [Header("Air movement")]
+    [Tooltip("Fox's acceleration in the air (there's a discrepancy because ground movement doesn't have acceleration)")]
     [SerializeField]
     private float m_AirAcceleration = 3f;
+
+    [Tooltip("Fox's max speed to cap off the air acceleration")]
     [SerializeField]
     private float m_MaxAirSpeed;
+
+    [Tooltip("How much ")]
     [SerializeField]
     private AnimationCurve m_AirAccelerationCurve;
-    private float MoveSpeed => m_Grounded.OnGround ? m_GroundMoveSpeed : m_AirAcceleration;
+    private float MoveSpeed => m_Grounded.OnGround ? m_GroundSpeed : m_AirAcceleration;
 
     private Rigidbody2D rb;
     private float directionX;

--- a/Assets/Scripts/HorizontalMovement.cs
+++ b/Assets/Scripts/HorizontalMovement.cs
@@ -5,14 +5,14 @@ public class HorizontalMovement : MonoBehaviour
 {
     [Tooltip("Speed of the player when in the air")]
     [SerializeField]
-    private float GroundMoveSpeed = 5;
+    private float m_GroundMoveSpeed = 5f;
     [SerializeField]
-    private float AirMoveSpeed = 3f;
+    private float m_AirAcceleration = 3f;
     [SerializeField]
-    private float MaxVelocityInputThreshold;
+    private float m_MaxAirSpeed;
     [SerializeField]
-    private AnimationCurve CoefficientCurve;
-    public float MoveSpeed => m_Grounded.OnGround ? GroundMoveSpeed : AirMoveSpeed;
+    private AnimationCurve m_AirAccelerationCurve;
+    private float MoveSpeed => m_Grounded.OnGround ? m_GroundMoveSpeed : m_AirAcceleration;
 
     private Rigidbody2D rb;
     private float directionX;
@@ -47,7 +47,7 @@ public class HorizontalMovement : MonoBehaviour
         }
         else
         {
-            rb.AddForce(new Vector2(directionX * AirMoveSpeed * 40 * GetAirCoefficient() , 0));
+            rb.AddForce(new Vector2(directionX * m_AirAcceleration * 40 * GetAirCoefficient() , 0));
         }
     }
 
@@ -56,12 +56,12 @@ public class HorizontalMovement : MonoBehaviour
         var coefficient = 0f;
         if ((directionX > 0 && rb.velocity.x > 0) || (directionX < 0 && rb.velocity.x < 0))
         {
-            coefficient = (MaxVelocityInputThreshold-Mathf.Clamp(Mathf.Abs(rb.velocity.x), 0, MaxVelocityInputThreshold))/MaxVelocityInputThreshold;
+            coefficient = (m_MaxAirSpeed-Mathf.Clamp(Mathf.Abs(rb.velocity.x), 0, m_MaxAirSpeed))/m_MaxAirSpeed;
         }
         else
         {
             coefficient = 1;
         }
-        return CoefficientCurve.Evaluate(coefficient);
+        return m_AirAccelerationCurve.Evaluate(coefficient);
     }
 }

--- a/Assets/Scripts/HorizontalMovement.cs
+++ b/Assets/Scripts/HorizontalMovement.cs
@@ -3,22 +3,21 @@ using UnityEngine.InputSystem;
 
 public class HorizontalMovement : MonoBehaviour
 {
-    public float MoveSpeed => m_Grounded.OnGround ? GroundMoveSpeed : AirMoveSpeed;
-
     [Tooltip("Speed of the player when in the air")]
-    public float AirMoveSpeed = 3f;
+    [SerializeField]
+    private float GroundMoveSpeed = 5;
+    [SerializeField]
+    private float AirMoveSpeed = 3f;
     [SerializeField]
     private float MaxVelocityInputThreshold;
     [SerializeField]
     private AnimationCurve CoefficientCurve;
-    [SerializeField]
-    private float GroundMoveSpeed = 5;
+    public float MoveSpeed => m_Grounded.OnGround ? GroundMoveSpeed : AirMoveSpeed;
 
     private Rigidbody2D rb;
     private float directionX;
     private Grounded m_Grounded;
     private AnchorThrower m_Thrower;
-    
     
     private void Start()
     {


### PR DESCRIPTION
# [POC-156: Rename weirdly named variables](https://www.notion.so/Rename-Max-Velocity-Input-Threshold-Ground-Move-Speed-373ccd03a4104cf6a43d2b952480527c?pvs=4)
## Changes summary:
- Renamed horizontal movement variables
- Added headers to separate variables into sensible groups
- Also added tooltips to help designers understand the purposes of the variables

## Note:
- Don't worry about the scene and prefab changes. Because the variables were renamed, I needed to refill in the values to match how it was before

## Checklist before requesting a review:
- [x] I have run the game locally
- [x] I have performed self-review on my code
- [x] I have confirmed critical features still function