### PR TITLE
FOX 101 fix chain recall bug

### DIFF
--- a/Assets/Prefabs/PlayerFox.prefab
+++ b/Assets/Prefabs/PlayerFox.prefab
@@ -25,6 +25,7 @@ GameObject:
   - component: {fileID: 2160122249298376338}
   - component: {fileID: 2794392424498695009}
   - component: {fileID: 8583358091099009673}
+  - component: {fileID: 8015112956025727630}
   m_Layer: 6
   m_Name: PlayerFox
   m_TagString: Player
@@ -336,7 +337,7 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 107137074636933804}
-  m_Enabled: 1
+  m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: b437cfd50d5e4419987f5bcf19a16a52, type: 3}
   m_Name: 
@@ -502,6 +503,51 @@ CapsuleCollider2D:
   m_Offset: {x: 0, y: 0.25}
   m_Size: {x: 0.5, y: 1.5}
   m_Direction: 0
+--- !u!61 &8015112956025727630
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 107137074636933804}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: -0.25}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 0.48, y: 0.5}
+  m_EdgeRadius: 0
 --- !u!1 &6063310992840300421
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Levels to port/Level 1/Stage 3.unity
+++ b/Assets/Scenes/Levels to port/Level 1/Stage 3.unity
@@ -490,7 +490,7 @@ LineRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 159550146}
-  m_Enabled: 0
+  m_Enabled: 1
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
@@ -1548,11 +1548,7 @@ PrefabInstance:
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
-    m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 107137074636933804, guid: fea7d46b09dd64780ba611993068e295,
-        type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 2127809754}
+    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: fea7d46b09dd64780ba611993068e295, type: 3}
 --- !u!1001 &796463837
 PrefabInstance:
@@ -1742,12 +1738,6 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 7608014636333094128, guid: 7e0aa05e90f61a14cb94da7fbfb5bd51,
     type: 3}
   m_PrefabInstance: {fileID: 248336827}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &990014111 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 107137074636933804, guid: fea7d46b09dd64780ba611993068e295,
-    type: 3}
-  m_PrefabInstance: {fileID: 700798260}
   m_PrefabAsset: {fileID: 0}
 --- !u!4 &1099414717 stripped
 Transform:
@@ -3162,6 +3152,16 @@ PrefabInstance:
       propertyPath: Player
       value: 
       objectReference: {fileID: 2127809724}
+    - target: {fileID: 8532552572255201571, guid: 36bf46491239d45478ae69d50018f3b5,
+        type: 3}
+      propertyPath: AnchorOffset.y
+      value: 0.25
+      objectReference: {fileID: 0}
+    - target: {fileID: 8532552572255201571, guid: 36bf46491239d45478ae69d50018f3b5,
+        type: 3}
+      propertyPath: PlayerOffset.y
+      value: 0.25
+      objectReference: {fileID: 0}
     - target: {fileID: 8532552572255201572, guid: 36bf46491239d45478ae69d50018f3b5,
         type: 3}
       propertyPath: m_RootOrder
@@ -7855,48 +7855,3 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 700798260}
   m_PrefabAsset: {fileID: 0}
---- !u!61 &2127809754
-BoxCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 990014111}
-  m_Enabled: 1
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_ForceSendLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ForceReceiveLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ContactCaptureLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_CallbackLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_IsTrigger: 0
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: 0, y: -0.25}
-  m_SpriteTilingProperty:
-    border: {x: 0, y: 0, z: 0, w: 0}
-    pivot: {x: 0, y: 0}
-    oldSize: {x: 0, y: 0}
-    newSize: {x: 0, y: 0}
-    adaptiveTilingThreshold: 0
-    drawMode: 0
-    adaptiveTiling: 0
-  m_AutoTiling: 0
-  serializedVersion: 2
-  m_Size: {x: 0.48, y: 0.5}
-  m_EdgeRadius: 0

--- a/Assets/Scripts/ChainClimber.cs
+++ b/Assets/Scripts/ChainClimber.cs
@@ -47,7 +47,7 @@ public class ChainClimber : MonoBehaviour
         var anchorInteractAction = playerInput.actions["Mount"];
 
         anchorInteractAction.started += DoMount;
-        anchorInteractAction.canceled += DoDismount;
+        //anchorInteractAction.canceled += DoDismount;
 
 		AnchorHolder.pickup += Dismount;
     }

--- a/Assets/Scripts/IdealChain.cs
+++ b/Assets/Scripts/IdealChain.cs
@@ -64,6 +64,19 @@ public class IdealChain : MonoBehaviour
 		m_MaxDistanceJoint.connectedBody = Anchor;
 		m_MaxDistanceJoint.distance = MaxLength;
 		m_MaxDistanceJoint.enableCollision = true;
+
+		AnchorHolder.pickup += ResetPoints;
+	}
+
+	private void ResetPoints()
+	{
+		m_Points.Clear();
+
+		m_Points = new List<ChainPoint>
+		{
+			new ChainPoint(Anchor),
+			new ChainPoint(Player),
+		};
 	}
 
 	private void FixedUpdate()
@@ -71,7 +84,7 @@ public class IdealChain : MonoBehaviour
 		UpdatePoints();
 		UpdateDistanceJoints();
 		ApplyTensionForces();
-		//UpdateLineRenderer();
+		UpdateLineRenderer();
 	}
 
 	private bool Sweep(Vector2 origin, Vector2 from, Vector2 to, out ChainPoint point)

--- a/Assets/Scripts/PhysicsChain.cs
+++ b/Assets/Scripts/PhysicsChain.cs
@@ -29,6 +29,7 @@ public class PhysicsChain : MonoBehaviour
 	private void Start()
 	{
 		CreateCompactChain();
+		Recall.activate += ResetChain;
 
 		//m_AnchorTargetJoint = m_Links.First().gameObject.AddComponent<TargetJoint2D>();
 		//m_AnchorTargetJoint.anchor = Vector2.zero;
@@ -126,5 +127,18 @@ public class PhysicsChain : MonoBehaviour
 		hingeJoint.autoConfigureConnectedAnchor = false;
 		hingeJoint.connectedAnchor = new Vector2(0, LinkAnchorOffset);
 		hingeJoint.anchor = new Vector2(0, -LinkAnchorOffset);
+	}
+
+	public void ResetChain()
+	{
+		foreach (Rigidbody2D rb in m_Links)
+		{
+			rb.transform.position = Player.position;
+		}
+	}
+
+	public void OnDestroy()
+	{
+		Recall.activate -= ResetChain;
 	}
 }

--- a/Assets/Scripts/Recall.cs
+++ b/Assets/Scripts/Recall.cs
@@ -5,6 +5,10 @@ using UnityEngine.InputSystem;
 
 public class Recall : MonoBehaviour
 {
+
+	public delegate void Trigger();
+	public static event Trigger activate;
+
 	private Anchor m_Anchor;
 	private AnchorHolder m_Holder;
 	private InputAction m_RecallAction;
@@ -17,13 +21,19 @@ public class Recall : MonoBehaviour
 		m_Anchor = FindObjectOfType<Anchor>();
 		m_Holder = GetComponent<AnchorHolder>();
 		m_RecallAction = GetComponent<PlayerInput>().actions["Recall"];
-		m_RecallAction.performed += ctx => Activate();
+		m_RecallAction.performed += Activate;
 	}
 
-	private void Activate()
+	private void Activate(InputAction.CallbackContext context)
 	{
 		AudioController.PlaySound(m_RecallSound, 1, 1, MixerGroup.SFX);
 		m_Anchor.transform.position = transform.position;
 		m_Holder.ForcePickup();
+		activate.Invoke();
+	}
+
+	private void OnDestroy()
+	{
+		m_RecallAction.performed -= Activate;
 	}
 }


### PR DESCRIPTION
# [FOX 101: fix chain recall bug](https://www.notion.so/a-foxs-tale/Fix-Chain-Getting-stuck-in-walls-after-recalling-4f748efeb107499b900ef3007a6783d6?pvs=4)

**Test scene (if any):**

## Changes summary: 
- visual chain resets its position when recall is activated
- physical chain resets its points when anchor is picked up (this is called by recall also)
- disabled dismount on action cancel as it made swinging at different chain lengths impossible

## Checklist before requesting a review:
- [ ] I have run the game locally
- [ ] I have performed self-review on my code
- [ ] I have confirmed critical features still function
