### PR TITLE
FOX-124: Dynamic VFX Shape Scaling

### DIFF
--- a/Assets/Art/2D/LevelElements/PSD ASSETS.psd.meta
+++ b/Assets/Art/2D/LevelElements/PSD ASSETS.psd.meta
@@ -1,0 +1,140 @@
+fileFormatVersion: 2
+guid: 1d11cec4e331a104da3c9202148beb07
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 12
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 1
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+    flipGreenChannel: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  ignoreMipmapLimit: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 1
+    aniso: 1
+    mipBias: 0
+    wrapU: 0
+    wrapV: 0
+    wrapW: 0
+  nPOTScale: 1
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 0
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 0
+  spriteTessellationDetail: -1
+  textureType: 0
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  swizzle: 50462976
+  cookieLightType: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Server
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: WebGL
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+    nameFileIdTable: {}
+  mipmapLimitGroupName: 
+  pSDRemoveMatte: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Forcefield.prefab
+++ b/Assets/Prefabs/Forcefield.prefab
@@ -147,6 +147,7 @@ GameObject:
   - component: {fileID: 3754421894374030316}
   - component: {fileID: 7642590366845207327}
   - component: {fileID: 3497578039071984159}
+  - component: {fileID: 8499191584684451982}
   m_Layer: 12
   m_Name: Particle System
   m_TagString: Untagged
@@ -808,7 +809,7 @@ ParticleSystem:
     donutRadius: 0.2
     m_Position: {x: 0, y: 0, z: 0}
     m_Rotation: {x: 0, y: 0, z: 0}
-    m_Scale: {x: 1, y: 0.12, z: 1}
+    m_Scale: {x: 1, y: 0.13033594, z: 1}
     placementMode: 0
     m_MeshMaterialIndex: 0
     m_MeshNormalOffset: 0
@@ -4991,6 +4992,20 @@ ParticleSystemRenderer:
   m_MeshWeighting2: 1
   m_MeshWeighting3: 1
   m_MaskInteraction: 0
+--- !u!114 &8499191584684451982
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4702734924406769335}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0c2a7d9aaec5cad4195dff4a0f032644, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_ContainerTransform: {fileID: 8972524248413476101}
+  m_ParticleSystem: {fileID: 7642590366845207327}
 --- !u!1 &8972524247347898710
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Forcefield.prefab
+++ b/Assets/Prefabs/Forcefield.prefab
@@ -26,7 +26,7 @@ Transform:
   m_GameObject: {fileID: 2736298242731134589}
   m_LocalRotation: {x: -0, y: -0, z: -0.7071068, w: 0.7071068}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 23.334494, y: 1.7241377, z: 1}
+  m_LocalScale: {x: 9.27, y: 0.2430504, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 8972524248413476101}
@@ -808,7 +808,7 @@ ParticleSystem:
     donutRadius: 0.2
     m_Position: {x: 0, y: 0, z: 0}
     m_Rotation: {x: 0, y: 0, z: 0}
-    m_Scale: {x: 4.15, y: -0.18, z: 1}
+    m_Scale: {x: 1, y: 0.12, z: 1}
     placementMode: 0
     m_MeshMaterialIndex: 0
     m_MeshNormalOffset: 0
@@ -4960,7 +4960,7 @@ ParticleSystemRenderer:
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
   m_SortingLayer: 0
-  m_SortingOrder: 0
+  m_SortingOrder: 1
   m_RenderMode: 0
   m_MeshDistribution: 0
   m_SortMode: 0
@@ -5067,7 +5067,7 @@ BoxCollider2D:
     adaptiveTiling: 0
   m_AutoTiling: 0
   serializedVersion: 2
-  m_Size: {x: 7, y: 1}
+  m_Size: {x: 1, y: 0.9}
   m_EdgeRadius: 0
 --- !u!114 &8972524247347898705
 MonoBehaviour:
@@ -5106,17 +5106,17 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8972524248413476106}
-  m_LocalRotation: {x: 0, y: 0, z: 0.7071068, w: 0.7071068}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 93.5, y: -14, z: -0.060036555}
-  m_LocalScale: {x: 0.58, y: 0.042855002, z: 1}
+  m_LocalScale: {x: 1, y: 0.13033594, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 8972524247347898711}
   - {fileID: 5066200985948673917}
   - {fileID: 3754421894374030316}
   m_Father: {fileID: 0}
-  m_RootOrder: 18
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 90}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!212 &8972524248413476100
 SpriteRenderer:
   m_ObjectHideFlags: 0
@@ -5163,7 +5163,7 @@ SpriteRenderer:
   m_FlipX: 0
   m_FlipY: 0
   m_DrawMode: 1
-  m_Size: {x: 7.15, y: 3.4}
+  m_Size: {x: 1, y: 1}
   m_AdaptiveModeThreshold: 0.5
   m_SpriteTileMode: 0
   m_WasSpriteAssigned: 1
@@ -5206,11 +5206,11 @@ BoxCollider2D:
     border: {x: 0, y: 0, z: 0, w: 0}
     pivot: {x: 0.5, y: 0.5}
     oldSize: {x: 20.2, y: 10.8}
-    newSize: {x: 7.15, y: 3.4}
+    newSize: {x: 1, y: 1}
     adaptiveTilingThreshold: 0.5
     drawMode: 1
     adaptiveTiling: 0
   m_AutoTiling: 0
   serializedVersion: 2
-  m_Size: {x: 7.16, y: 1}
+  m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0

--- a/Assets/Scenes/Test/ForcefieldTest.unity
+++ b/Assets/Scenes/Test/ForcefieldTest.unity
@@ -221,6 +221,7 @@ MonoBehaviour:
   m_Dithering: 0
   m_ClearDepth: 1
   m_AllowXRRendering: 1
+  m_AllowHDROutput: 1
   m_UseScreenCoordOverride: 0
   m_ScreenSizeOverride: {x: 0, y: 0, z: 0, w: 0}
   m_ScreenCoordScaleBias: {x: 0, y: 0, z: 0, w: 0}
@@ -719,6 +720,7 @@ MonoBehaviour:
     ModeOverride: 0
     LensShift: {x: 0, y: 0}
     GateFit: 2
+    FocusDistance: 10
     m_SensorSize: {x: 1, y: 1}
   m_Transitions:
     m_BlendHint: 0
@@ -2607,6 +2609,11 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 7642590366845207327, guid: b5ebb6d719d7fd34dbd929c25d66d34e,
+        type: 3}
+      propertyPath: ShapeModule.m_Scale.x
+      value: 29.759401
+      objectReference: {fileID: 0}
     - target: {fileID: 8972524248413476101, guid: b5ebb6d719d7fd34dbd929c25d66d34e,
         type: 3}
       propertyPath: m_RootOrder
@@ -2615,7 +2622,7 @@ PrefabInstance:
     - target: {fileID: 8972524248413476101, guid: b5ebb6d719d7fd34dbd929c25d66d34e,
         type: 3}
       propertyPath: m_LocalScale.x
-      value: 4.5
+      value: 29.759401
       objectReference: {fileID: 0}
     - target: {fileID: 8972524248413476101, guid: b5ebb6d719d7fd34dbd929c25d66d34e,
         type: 3}
@@ -2685,6 +2692,11 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 7642590366845207327, guid: b5ebb6d719d7fd34dbd929c25d66d34e,
+        type: 3}
+      propertyPath: ShapeModule.m_Scale.x
+      value: 26.657694
+      objectReference: {fileID: 0}
     - target: {fileID: 8972524248413476101, guid: b5ebb6d719d7fd34dbd929c25d66d34e,
         type: 3}
       propertyPath: m_RootOrder
@@ -2693,7 +2705,7 @@ PrefabInstance:
     - target: {fileID: 8972524248413476101, guid: b5ebb6d719d7fd34dbd929c25d66d34e,
         type: 3}
       propertyPath: m_LocalScale.x
-      value: 3.78
+      value: 26.657694
       objectReference: {fileID: 0}
     - target: {fileID: 8972524248413476101, guid: b5ebb6d719d7fd34dbd929c25d66d34e,
         type: 3}
@@ -3588,10 +3600,20 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 7642590366845207327, guid: b5ebb6d719d7fd34dbd929c25d66d34e,
+        type: 3}
+      propertyPath: ShapeModule.m_Scale.x
+      value: 3.85
+      objectReference: {fileID: 0}
     - target: {fileID: 8972524248413476101, guid: b5ebb6d719d7fd34dbd929c25d66d34e,
         type: 3}
       propertyPath: m_RootOrder
       value: 16
+      objectReference: {fileID: 0}
+    - target: {fileID: 8972524248413476101, guid: b5ebb6d719d7fd34dbd929c25d66d34e,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 3.8087926
       objectReference: {fileID: 0}
     - target: {fileID: 8972524248413476101, guid: b5ebb6d719d7fd34dbd929c25d66d34e,
         type: 3}

--- a/Assets/Scripts/Utils.meta
+++ b/Assets/Scripts/Utils.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 788d02986582509448fa51ac23d5b051
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Utils/VFX.meta
+++ b/Assets/Scripts/Utils/VFX.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0baae8f7af1c7d543a43231282919996
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Utils/VFX/DynamicVFXShape.cs
+++ b/Assets/Scripts/Utils/VFX/DynamicVFXShape.cs
@@ -1,0 +1,42 @@
+using UnityEngine;
+
+/// <summary>
+/// Dynamically update the scaling of particle system's shape according to its container's scaling (Only runs in edit mode).
+/// </summary>
+[ExecuteInEditMode]
+public class DynamicVFXShape : MonoBehaviour
+{
+    [SerializeField]
+    private Transform m_ContainerTransform;
+
+    [SerializeField]
+    private ParticleSystem m_ParticleSystem;
+
+    private void Start()
+    {
+        if (m_ParticleSystem == null)
+            Debug.LogError($"Object {gameObject.name} is missing a particle system component. Please assign a particle system component.");
+
+        if (m_ContainerTransform == null)
+            Debug.LogWarning($"Object {gameObject.name} doesn't have a parent object to adjust its shape to.");
+    }
+
+    private void Update()
+    {
+        if (m_ContainerTransform == null || m_ParticleSystem == null)
+            return;
+
+        UpdateBoxLength();
+    }
+
+    private void UpdateBoxLength()
+    {
+        Vector3 containerScale = m_ContainerTransform.localScale;
+
+        // We're assuming the shape of the system is a box, so by
+        // scaling the rectangular container, we're hoping to also
+        // scale the shape of the system accordingly
+        ParticleSystem.ShapeModule shapeModule = m_ParticleSystem.shape;
+        shapeModule.scale = containerScale;
+    }
+}

--- a/Assets/Scripts/Utils/VFX/DynamicVFXShape.cs.meta
+++ b/Assets/Scripts/Utils/VFX/DynamicVFXShape.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0c2a7d9aaec5cad4195dff4a0f032644
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
# [FOX-124: Dynamic VFX Shape Scaling](https://www.notion.so/a-foxs-tale/Dynamic-Force-Field-VFX-b8ca0d029c924c2cb84348fa30f3d176?pvs=4)

**Test scene (if any):**
- `Scenes/Test/ForcefieldTest.unity`

## Changes summary:
- Normalized values for forcefield's components and children for easy scaling while still maintaining proportion
- Added EditMode script to update particle system's shape scale according to its container

Note: This is gonna be merged to branch FOX-112 for now as 112 contains large amounts of changes from other work. This also won't trigger a build pipeline

## Checklist before requesting a review:
- [x] I have run the game locally
- [x] I have performed self-review on my code
- [x] I have confirmed critical features still function
