### PR TITLE
feat: added restart to the pause menu and removed unused menu options…

### DIFF
--- a/Assets/Scenes/Levels/Harley Level 1.unity
+++ b/Assets/Scenes/Levels/Harley Level 1.unity
@@ -2942,16 +2942,8 @@ PrefabInstance:
       addedObject: {fileID: 1877467957}
     - targetCorrespondingSourceObject: {fileID: 107137074636933804, guid: fea7d46b09dd64780ba611993068e295,
         type: 3}
-      insertIndex: -1
+      insertIndex: 20
       addedObject: {fileID: 1877467958}
-    - targetCorrespondingSourceObject: {fileID: 107137074636933804, guid: fea7d46b09dd64780ba611993068e295,
-        type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 1877467977}
-    - targetCorrespondingSourceObject: {fileID: 107137074636933804, guid: fea7d46b09dd64780ba611993068e295,
-        type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 1877467978}
   m_SourcePrefab: {fileID: 100100000, guid: fea7d46b09dd64780ba611993068e295, type: 3}
 --- !u!50 &1852206378 stripped
 Rigidbody2D:
@@ -3049,30 +3041,6 @@ MonoBehaviour:
     serializedVersion: 2
     m_Bits: 0
   m_MantleForce: 0
---- !u!114 &1877467977
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1877467943}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: ad647ed0988f34484b0ea50aa1cfbd51, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &1877467978
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1877467943}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 67cd3429e1ab24650a527b99fa4bd1f4, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &1880292944
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/UI/PauseGame.cs
+++ b/Assets/Scripts/UI/PauseGame.cs
@@ -15,6 +15,6 @@ public class PauseGame : MonoBehaviour
 
     private void OnPause()	//uses input system
     {
-        m_PauseMenu.GetComponent<Pause>().TryPause();
+        m_PauseMenu.GetComponent<ShowPauseMenu>().TryPause();
     }
 }

--- a/Assets/Scripts/UI/ShowPauseMenu.cs
+++ b/Assets/Scripts/UI/ShowPauseMenu.cs
@@ -15,9 +15,10 @@ public class ShowPauseMenu : MonoBehaviour
 	private void OnEnable()
 	{
 		s_GamePaused = false;
-        //Get levelselect object
-        GameObject m_LevelSelectObject = GameObject.Find("LevelSelectMenu");
-		m_LevelSelectRoot = m_LevelSelectObject.GetComponent<UIDocument>().rootVisualElement;
+		// Hiding level select menu for now
+		//Get levelselect object
+		// GameObject m_LevelSelectObject = GameObject.Find("LevelSelectMenu");
+		// m_LevelSelectRoot = m_LevelSelectObject.GetComponent<UIDocument>().rootVisualElement;
 		//enable the component (its disabled by default so doesnt get in the way of the scene view when editting levels
 		GetComponent<UIDocument>().enabled = true;
 		m_PauseRoot = GetComponent<UIDocument>().rootVisualElement;
@@ -25,41 +26,43 @@ public class ShowPauseMenu : MonoBehaviour
 		m_PauseRoot.style.display = DisplayStyle.None;
 		//getting all the buttons
 		Button m_ResumeButton = m_PauseRoot.Q<Button>("Resume");
-		Button m_LevelSelectButton = m_PauseRoot.Q<Button>("LevelSelect");
-		Button m_SettingsButton = m_PauseRoot.Q<Button>("Settings");
-		Button m_MainMenuButton = m_PauseRoot.Q<Button>("MainMenu");
+		Button m_RestartButton = m_PauseRoot.Q<Button>("Restart");
+		// Hiding these 3 buttons for now
+		// Button m_LevelSelectButton = m_PauseRoot.Q<Button>("LevelSelect");
+		// Button m_SettingsButton = m_PauseRoot.Q<Button>("Settings");
+		// Button m_MainMenuButton = m_PauseRoot.Q<Button>("MainMenu");
 
 		//Setting what dem buttons do
 		m_ResumeButton.clicked += () => UnpauseGame();
+		m_RestartButton.clicked += () => RestartGame();
+		// Hiding these UI screens for now
 		//Show levelselect ui
-		m_LevelSelectButton.clicked += () => m_LevelSelectRoot.style.display = DisplayStyle.Flex;
-		m_SettingsButton.clicked += () => Debug.Log("TODO Settings");
-		m_MainMenuButton.clicked += () => LoadScene("MainMenu");
+		// m_LevelSelectButton.clicked += () => m_LevelSelectRoot.style.display = DisplayStyle.Flex;
+		// m_SettingsButton.clicked += () => Debug.Log("TODO Settings");
+		// m_MainMenuButton.clicked += () => LoadScene("MainMenu");
 	}
 
 	//Note update in other scripts still runs when game is paused (Timescale = 0) but FixedUpdate does NOT. Input checks in other Update()s still go off so need to check if Pause.s_GamePaused = false for other stuff.
 
 
-    public void TryPause()	//uses input system
-    {
-        if (s_GamePaused)
-        {
-            //If currently paused:
-            UnpauseGame();
-        }
-        else
-        {
-            //If not paused:
-            PauseGame();
-        }
-    }
+	public void TryPause()  //uses input system
+	{
+		if (s_GamePaused)
+		{
+			//If currently paused:
+			UnpauseGame();
+		}
+		else
+		{
+			//If not paused:
+			PauseGame();
+		}
+	}
 
-
-
-    private void PauseGame()
+	private void PauseGame()
 	{
 		s_GamePaused = true;
-		m_PreviousTimeScale = Time.timeScale;	
+		m_PreviousTimeScale = Time.timeScale;
 		Time.timeScale = 0;
 		AudioListener.pause = true; //pauses audio
 		m_PauseRoot.style.display = DisplayStyle.Flex;
@@ -71,7 +74,16 @@ public class ShowPauseMenu : MonoBehaviour
 		Time.timeScale = m_PreviousTimeScale;   //Sets timescale to previous timescale (instead of 1) so that incase there was a slowmo effect then it doesnt cancel it.
 		AudioListener.pause = false;
 		m_PauseRoot.style.display = DisplayStyle.None;
-		m_LevelSelectRoot.style.display = DisplayStyle.None;
+		// m_LevelSelectRoot.style.display = DisplayStyle.None;
+	}
+
+	private void RestartGame()
+	{
+		s_GamePaused = false;
+		Time.timeScale = m_PreviousTimeScale;
+		AudioListener.pause = false;
+		m_PauseRoot.style.display = DisplayStyle.None;
+		SceneManager.LoadScene(SceneManager.GetActiveScene().name);
 	}
 
 	private void LoadScene(string scene)

--- a/Assets/UI/ButtonStyle.uss
+++ b/Assets/UI/ButtonStyle.uss
@@ -3,7 +3,6 @@
     flex-direction: column;
     align-items: flex-end;
     align-self: flex-end;
-    font-size: 16px;
     -unity-font-style: bold;
 }
 

--- a/Assets/UI/PauseMenu.uxml
+++ b/Assets/UI/PauseMenu.uxml
@@ -1,11 +1,12 @@
 <ui:UXML xmlns:ui="UnityEngine.UIElements" xmlns:uie="UnityEditor.UIElements" editor-extension-mode="False">
     <Style src="project://database/Assets/UI/ButtonStyle.uss?fileID=7433441132597879392&amp;guid=4682471baa914405b9f6bdfca6a180e4&amp;type=3#ButtonStyle" />
-    <ui:VisualElement name="VisualElement" style="flex-grow: 1; background-color: rgba(0, 0, 0, 0); background-image: url(&apos;project://database/Assets/Images/UI/treasure_map_texture.png?fileID=2800000&amp;guid=06bc814483298457e817b954ee84773e&amp;type=3#treasure_map_texture&apos;); -unity-background-scale-mode: scale-and-crop; display: flex; opacity: 1;">
-        <ui:VisualElement name="ButtonContainer" class="button-wrapper" style="flex-grow: 1; background-color: rgba(0, 0, 0, 0); font-size: 20px; -unity-font-style: bold-and-italic; align-self: center; justify-content: center;">
-            <ui:Button text="Resume" display-tooltip-when-elided="true" name="Resume" style="-unity-font-style: bold;" />
-            <ui:Button text="Level Select" display-tooltip-when-elided="true" name="LevelSelect" style="display: flex; font-size: 20px; -unity-font-style: bold;" />
-            <ui:Button text="Settings" display-tooltip-when-elided="true" name="Settings" style="-unity-font-style: bold;" />
-            <ui:Button text="Main Menu" display-tooltip-when-elided="true" name="MainMenu" style="-unity-font-style: bold;" />
+    <ui:VisualElement name="VisualElement" style="flex-grow: 1; background-color: rgba(0, 0, 0, 0); background-image: url(&apos;project://database/Assets/Images/UI/treasure_map_texture.png?fileID=2800000&amp;guid=06bc814483298457e817b954ee84773e&amp;type=3#treasure_map_texture&apos;); -unity-background-scale-mode: scale-and-crop; display: flex; opacity: 1; align-self: auto; justify-content: center; align-items: center; -unity-text-align: middle-left;">
+        <ui:VisualElement name="ContentWrapper" style="flex-grow: 1; background-color: rgba(0, 0, 0, 0); justify-content: center; align-self: center; align-items: center; -unity-text-align: middle-left; position: absolute; height: 257px; font-size: 30px;">
+            <ui:Label tabindex="-1" text="Game Paused" display-tooltip-when-elided="true" name="GamePaused" style="-unity-font-style: bold; color: rgb(255, 255, 255); font-size: 40px; align-self: auto; justify-content: flex-end; align-items: auto; -unity-text-align: middle-left; margin-top: 0; position: relative;" />
+            <ui:VisualElement name="ButtonContainer" class="button-wrapper" style="flex-grow: 1; background-color: rgba(0, 0, 0, 0); font-size: 20px; -unity-font-style: bold-and-italic; align-self: auto; justify-content: center; align-items: auto; -unity-text-align: middle-left; position: relative;">
+                <ui:Button text="Resume" display-tooltip-when-elided="true" name="Resume" style="-unity-font-style: bold; font-size: 30px;" />
+                <ui:Button text="Restart" display-tooltip-when-elided="true" name="Restart" style="display: flex; font-size: 30px; -unity-font-style: bold;" />
+            </ui:VisualElement>
         </ui:VisualElement>
     </ui:VisualElement>
 </ui:UXML>


### PR DESCRIPTION
# [FOX-127: Add restart to pause menu](https://www.notion.so/a-foxs-tale/Add-restart-to-the-pause-menu-d4c19bffced64dbaa316995c9f70e056)

**Test scene (if any):**
- `Scenes/SceneName.unity`

## Changes summary:
- added restart option to the pause menu
- removed menu/level select/options from the pause menu

## Checklist before requesting a review:
- [x] I have run the game locally
- [x] I have performed self-review on my code
- [x] I have confirmed critical features still function
