### PR TITLE
FOX-182: Remove PR heading from PR template

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,5 +1,3 @@
-# [FOX-ticket_number: Ticket name](ticket-link-here)
-
 **Test scene (if any):**
 - `Scenes/SceneName.unity`
 


### PR DESCRIPTION
## Changes summary:
- Nuked the PR heading from the PR template, as we already have the PR title, and notion's doing the linking for us

## Checklist before requesting a review:
~~- [ ] I have run the game locally~~
~~- [ ] I have performed self-review on my code~~
~~- [ ] I have confirmed critical features still function~~
