### PR TITLE
FOX-270-BUG-Anchor-gets-disabled-on-start-

### DIFF
--- a/Assets/Scripts/Anchor.cs
+++ b/Assets/Scripts/Anchor.cs
@@ -24,8 +24,6 @@ public class Anchor : MonoBehaviour
 	private float m_ShakeDuration;
 	private float m_ShakeAmplitudeTimer;
 	private Vector3 m_ShakePos;
-	[SerializeField]
-	private GameObject m_TimerSprite;
 
 	[SerializeField]
 	private AudioClip m_AnchorLand;
@@ -50,8 +48,6 @@ public class Anchor : MonoBehaviour
 		m_Rigidbody.useFullKinematicContacts = true;
 
 		m_FreeTimer = new Timer();
-
-		m_TimerSprite.SetActive(false);
 	}
 
 	private void Update()
@@ -126,11 +122,9 @@ public class Anchor : MonoBehaviour
 		m_ShakePos = transform.position;
 		m_ShakeAmplitudeTimer = duration;
 		m_ShakeDuration = duration;
-		m_TimerSprite.SetActive(true);
 		yield return new WaitForSeconds(duration);
 		m_Shake = false;
 		transform.position = m_ShakePos;
-		m_TimerSprite.SetActive(false);
 	}
 
 	private IEnumerator DisableFoxCollision()


### PR DESCRIPTION
FIXED ANCHOR GETTING DISABLED. There was some old unused code that was disabling the anchor. The old Stall Sprite circle timer code was disabling the anchor. Removed it and works now

## Checklist before requesting a review:
- [x] I have run the game locally
- [x] I have performed self-review on my code
- [x] I have confirmed critical features still function
