### PR TITLE
FOX-282: Level end loads next level

### DIFF
--- a/Assets/Scenes/LevelEnd.unity
+++ b/Assets/Scenes/LevelEnd.unity
@@ -715,6 +715,8 @@ MonoBehaviour:
   m_ProfileTextPadding: 60
   m_TopProfileSpawn: {fileID: 8891925998897178693}
   m_PlayerProfileSpawn: {fileID: 937314809}
+  m_SilverTrophy: {fileID: 445744707}
+  m_BronzeTrophy: {fileID: 651715356}
 --- !u!1 &533723404
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Environment/LevelSelectionUI.cs
+++ b/Assets/Scripts/Environment/LevelSelectionUI.cs
@@ -14,8 +14,7 @@ public class LevelSelectionUI : MonoBehaviour
             if (!scenePath.Contains("LevelSelection") && !scenePath.Contains("LevelEnd"))
             {
                 LevelSelector levelSelector = Instantiate(m_levelSelectorPrefab, gameObject.transform);
-                //levelSelector.Initialize(i, i.ToString());    Uncomment this code when it comes to actual build so only level number is displayed
-                levelSelector.Initialize(i, System.IO.Path.GetFileNameWithoutExtension(scenePath));
+                levelSelector.Initialize(i, $"Level {i}");
             }
         }
     }

--- a/Assets/Scripts/Environment/LevelSelector.cs
+++ b/Assets/Scripts/Environment/LevelSelector.cs
@@ -1,5 +1,4 @@
 using UnityEngine;
-using UnityEngine.SceneManagement;
 using TMPro;
 
 public class LevelSelector : MonoBehaviour
@@ -30,8 +29,6 @@ public class LevelSelector : MonoBehaviour
 
 	public void OpenScene()
 	{
-        //Get the scene name from the build index:
-        string m_SceneName = System.IO.Path.GetFileNameWithoutExtension(SceneUtility.GetScenePathByBuildIndex(m_levelIndex));
-        StartCoroutine(m_HoleTransition.ShrinkParentObject(m_SceneName));
-	}
+        StartCoroutine(m_HoleTransition.ShrinkParentObject(m_levelIndex));
+    }
 }

--- a/Assets/Scripts/LevelEnd.cs
+++ b/Assets/Scripts/LevelEnd.cs
@@ -33,9 +33,9 @@ public class LevelEnd : MonoBehaviour
             // Call the TimerAction method after the specified delay
             Invoke("TimerEnded", m_EndDelay);
             SaveUtils.RecordTime(m_GameTimer.TimeElapsed);
-            PlayerPrefs.SetString("LastScene", SceneManager.GetActiveScene().name);
+            PlayerPrefs.SetInt("LastScene", SceneManager.GetActiveScene().buildIndex);
 
-            SaveUtils.SaveProfile(); // To be deleted after other levels are added
+
         }
     }
 

--- a/Assets/Scripts/LevelEnd.cs
+++ b/Assets/Scripts/LevelEnd.cs
@@ -34,8 +34,6 @@ public class LevelEnd : MonoBehaviour
             Invoke("TimerEnded", m_EndDelay);
             SaveUtils.RecordTime(m_GameTimer.TimeElapsed);
             PlayerPrefs.SetInt("LastScene", SceneManager.GetActiveScene().buildIndex);
-
-
         }
     }
 
@@ -47,7 +45,7 @@ public class LevelEnd : MonoBehaviour
             // This method will be called after the specified delay
 
             //Debug.Log("Timer action executed!");
-            StartCoroutine(m_HoleTransition.ShrinkParentObject("LevelEnd"));
+            StartCoroutine(m_HoleTransition.ShrinkParentObject(SceneManager.GetActiveScene().buildIndex + 1)); // Load the next scene (level 3 will load leaderboard next)
 
         }
     }

--- a/Assets/Scripts/UI/CloseOrOpenCircle.cs
+++ b/Assets/Scripts/UI/CloseOrOpenCircle.cs
@@ -79,7 +79,7 @@ public class CloseOrOpenCircle : MonoBehaviour
         StartCoroutine(GrowParentObject());
     }
 
-    public IEnumerator ShrinkParentObject(String m_SceneToOpen = null)
+    public IEnumerator ShrinkParentObject(int m_SceneToOpen = 0)
     {
         
 
@@ -113,9 +113,9 @@ public class CloseOrOpenCircle : MonoBehaviour
 
         //Tries to load the inputted scene. Otherwise loads the current scene.
         //Debug.Log("Open New Scene");
-        if(m_SceneToOpen == null)
+        if(m_SceneToOpen == 0)
         {
-            m_SceneToOpen = SceneManager.GetActiveScene().name;
+            m_SceneToOpen = SceneManager.GetActiveScene().buildIndex;
         }
         SceneManager.LoadScene(m_SceneToOpen);
         

--- a/Assets/Scripts/UI/LevelEndUI.cs
+++ b/Assets/Scripts/UI/LevelEndUI.cs
@@ -1,5 +1,3 @@
-using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
 using TMPro;
 using UnityEngine.SceneManagement;
@@ -26,13 +24,13 @@ public class LevelEndUI : MonoBehaviour
 
     public void RestartLevelButtonPressed()
     {
-        string m_LastScene = PlayerPrefs.GetString("LastScene");
-        StartCoroutine(m_HoleTransition.ShrinkParentObject(m_LastScene));
+        int lastSceneIndex = PlayerPrefs.GetInt("LastScene");
+        StartCoroutine(m_HoleTransition.ShrinkParentObject(lastSceneIndex));
     }
 
     public void LevelSelectButtonPressed()
     {
         SceneManager.LoadScene("LevelSelection");
-        //StartCoroutine(m_HoleTransition.ShrinkParentObject("LevelSelection"));
+        StartCoroutine(m_HoleTransition.ShrinkParentObject(0)); // 0 = LevelSelection
     }
 }

--- a/Assets/Scripts/Utils/SaveUtils.cs
+++ b/Assets/Scripts/Utils/SaveUtils.cs
@@ -33,7 +33,7 @@ public static class SaveUtils
         int index = SceneManager.GetActiveScene().buildIndex + levelCountBeforeLevel1;
 
         // If this is the first time saving, initialize profile
-        if (PlayerPrefs.HasKey($"Lv{index}Time"))
+        if (!PlayerPrefs.HasKey($"Lv{index}Time"))
         {
             InitializeProfile();
         }

--- a/ProjectSettings/EditorBuildSettings.asset
+++ b/ProjectSettings/EditorBuildSettings.asset
@@ -12,6 +12,12 @@ EditorBuildSettings:
     path: Assets/Scenes/Test/Brians Level Idea.unity
     guid: d7f4786e13a67444082c25716ea750f2
   - enabled: 1
+    path: Assets/Scenes/Test/More Levels from brian.unity
+    guid: 1934d6b27e22fcf438509e7d2a2a8957
+  - enabled: 1
+    path: Assets/Scenes/Test/Another Level From Brian For You You Are Welcome.unity
+    guid: 0a4bd3f3f1db8c54699508819401f1fe
+  - enabled: 1
     path: Assets/Scenes/LevelEnd.unity
     guid: bae3f84815e124cb69f970c2b42397c7
   m_configObjects: {}


### PR DESCRIPTION
**Test scene (if any):**
- `Scenes/LevelSelection.unity`

## Changes summary:
- Changed all instances of level loading using level index instead of string (this should increase performance by a little bit cuz we're using a faster search method)
- Made level end object loads next level also using level index

## Checklist before requesting a review:
- [x] I have run the game locally
- [x] I have performed self-review on my code
- [x] I have confirmed critical features still function
