### PR TITLE
Fixed anchor lock bug and flying bug

### DIFF
--- a/Assets/Prefabs/Anchor.prefab
+++ b/Assets/Prefabs/Anchor.prefab
@@ -391,6 +391,9 @@ MonoBehaviour:
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 4
+  m_GroundMask:
+    serializedVersion: 2
+    m_Bits: 256
   m_AnchorLand: {fileID: 8300000, guid: 29f783d1285a6d84096edf25705b36e5, type: 3}
   m_AnchorLodge: {fileID: 8300000, guid: b9667435767ef20409adeb860c227808, type: 3}
   m_AnchorBump: {fileID: 8300000, guid: d1c39d3d6816921488d81a5efec24c8d, type: 3}

--- a/Assets/Prefabs/Lilypad.prefab
+++ b/Assets/Prefabs/Lilypad.prefab
@@ -12,7 +12,7 @@ GameObject:
   - component: {fileID: 3302574766474727731}
   - component: {fileID: 1554401727858526928}
   - component: {fileID: 2828858079355535575}
-  m_Layer: 8
+  m_Layer: 17
   m_Name: Lilypad
   m_TagString: Lilypad
   m_Icon: {fileID: 0}

--- a/Assets/Prefabs/PlayerFox.prefab
+++ b/Assets/Prefabs/PlayerFox.prefab
@@ -287,7 +287,7 @@ MonoBehaviour:
       m_Calls: []
   m_GroundMask:
     serializedVersion: 2
-    m_Bits: 384
+    m_Bits: 131456
   m_HazardMask:
     serializedVersion: 2
     m_Bits: 2048

--- a/Assets/Prefabs/WaterVolume.prefab
+++ b/Assets/Prefabs/WaterVolume.prefab
@@ -43,6 +43,25 @@ BoxCollider2D:
   m_Enabled: 1
   m_Density: 1
   m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
   m_IsTrigger: 1
   m_UsedByEffector: 1
   m_UsedByComposite: 0
@@ -176,6 +195,25 @@ BoxCollider2D:
   m_Enabled: 1
   m_Density: 1
   m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
   m_IsTrigger: 1
   m_UsedByEffector: 1
   m_UsedByComposite: 0
@@ -221,7 +259,7 @@ BuoyancyEffector2D:
   m_UseColliderMask: 1
   m_ColliderMask:
     serializedVersion: 2
-    m_Bits: 423
+    m_Bits: 131495
   m_SurfaceLevel: 0.5
   m_Density: 16
   m_LinearDrag: 20
@@ -272,6 +310,25 @@ BoxCollider2D:
   m_Enabled: 1
   m_Density: 1
   m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
   m_IsTrigger: 1
   m_UsedByEffector: 1
   m_UsedByComposite: 0

--- a/Assets/Scenes/Test/More Levels from brian.unity
+++ b/Assets/Scenes/Test/More Levels from brian.unity
@@ -8772,10 +8772,30 @@ PrefabInstance:
       propertyPath: m_CooldownColour.r
       value: 0.8396226
       objectReference: {fileID: 0}
+    - target: {fileID: 2838516154636234219, guid: fea7d46b09dd64780ba611993068e295,
+        type: 3}
+      propertyPath: m_ConnectedAnchor.x
+      value: 0.39648885
+      objectReference: {fileID: 0}
+    - target: {fileID: 2838516154636234219, guid: fea7d46b09dd64780ba611993068e295,
+        type: 3}
+      propertyPath: m_ConnectedAnchor.y
+      value: 0.000005834735
+      objectReference: {fileID: 0}
     - target: {fileID: 3642870710035614992, guid: fea7d46b09dd64780ba611993068e295,
         type: 3}
       propertyPath: m_IsActive
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4077724322293946804, guid: fea7d46b09dd64780ba611993068e295,
+        type: 3}
+      propertyPath: m_ConnectedAnchor.x
+      value: 0.42218563
+      objectReference: {fileID: 0}
+    - target: {fileID: 4077724322293946804, guid: fea7d46b09dd64780ba611993068e295,
+        type: 3}
+      propertyPath: m_ConnectedAnchor.y
+      value: -0.0000008016359
       objectReference: {fileID: 0}
     - target: {fileID: 4250636120361761568, guid: fea7d46b09dd64780ba611993068e295,
         type: 3}

--- a/Assets/Scripts/Anchor.cs
+++ b/Assets/Scripts/Anchor.cs
@@ -132,14 +132,15 @@ public class Anchor : MonoBehaviour
 
 	private IEnumerator DisableFoxCollision()
 	{
+		if (m_State != AnchorState.Held)
+		{
+			var collider = GetComponent<Collider2D>();
+			collider.enabled = true;
+		}
+
 		gameObject.layer = LayerMask.NameToLayer("Ghost");
 		yield return new WaitForSeconds(0.1f);
         gameObject.layer = LayerMask.NameToLayer("Anchor");
-		if(m_State != AnchorState.Held)
-		{
-            var collider = GetComponent<Collider2D>();
-            collider.enabled = true;
-        }
 		
 
 	}

--- a/Assets/Scripts/Anchor.cs
+++ b/Assets/Scripts/Anchor.cs
@@ -26,6 +26,9 @@ public class Anchor : MonoBehaviour
 	private Vector3 m_ShakePos;
 
 	[SerializeField]
+	private LayerMask m_GroundMask;
+
+	[SerializeField]
 	private AudioClip m_AnchorLand;
 	[SerializeField]
 	private AudioClip m_AnchorLodge;
@@ -71,7 +74,7 @@ public class Anchor : MonoBehaviour
 		{
 			UpdateState(AnchorState.Lodged);
 		}
-		else if (!collision.gameObject.CompareTag("Player"))
+		else if (m_GroundMask == (m_GroundMask | (1 << collision.gameObject.layer)))
 		{
 			foreach (ContactPoint2D hitpos in collision.contacts)
 			{

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -25,7 +25,7 @@ TagManager:
   - BackgroundObjects
   - BreakableObjects
   - NoPostProcessing
-  - 
+  - Lilypad
   - 
   - 
   - 


### PR DESCRIPTION
**Test scene (if any):**
- `Scenes/test/More Levels From Brian.unity`

## Changes summary:
- anchor now has a layermask for checking collisions
- lilypad now has its own layer
- fox grounded layermask includes lilypads

## Checklist before requesting a review:
- [ ] I have run the game locally
- [ ] I have performed self-review on my code
- [ ] I have confirmed critical features still function
