### PR TITLE
FOX-319: Fix next scene loading

### DIFF
--- a/Assets/Scripts/Spike.cs
+++ b/Assets/Scripts/Spike.cs
@@ -29,7 +29,8 @@ public class Spike : MonoBehaviour
             S_Collided = true;
             if(m_HoleTransition != null)
             {
-                StartCoroutine(m_HoleTransition.ShrinkParentObject());
+                int currentSceneIndex = SceneManager.GetActiveScene().buildIndex;
+                StartCoroutine(m_HoleTransition.ShrinkParentObject(currentSceneIndex));
             }
             else
             {

--- a/Assets/Scripts/UI/CloseOrOpenCircle.cs
+++ b/Assets/Scripts/UI/CloseOrOpenCircle.cs
@@ -60,7 +60,8 @@ public class CloseOrOpenCircle : MonoBehaviour
             // Trigger the shrinking effect when the specified key is pressed
             if (Input.GetKeyDown(m_ShrinkKey))
             {
-                StartCoroutine(ShrinkParentObject());
+                int currentSceneIndex = SceneManager.GetActiveScene().buildIndex;
+                StartCoroutine(ShrinkParentObject(currentSceneIndex));
             }
 
             // Trigger the growing effect when the specified key is pressed
@@ -79,7 +80,7 @@ public class CloseOrOpenCircle : MonoBehaviour
         StartCoroutine(GrowParentObject());
     }
 
-    public IEnumerator ShrinkParentObject(int m_SceneToOpen = 0)
+    public IEnumerator ShrinkParentObject(int m_SceneToOpen)
     {
         
 
@@ -110,13 +111,6 @@ public class CloseOrOpenCircle : MonoBehaviour
 
         // Keep child's world scale intact when parent is at zero
         m_ChildTransform.localScale = m_ChildInitialWorldScale / 0.001f;
-
-        //Tries to load the inputted scene. Otherwise loads the current scene.
-        //Debug.Log("Open New Scene");
-        if(m_SceneToOpen == 0)
-        {
-            m_SceneToOpen = SceneManager.GetActiveScene().buildIndex;
-        }
         SceneManager.LoadScene(m_SceneToOpen);
         
 


### PR DESCRIPTION
**Test scene (if any):**
- Any scene with spikes: should still reload the same scene
- Level End (aka leaderboard, ***only test after this is merged***): pressing A to return to first scene should load the first scene

## Changes summary:
- Removed redundant failsafe logic
- Made sure all calls with empty params now have index 0 as the passed value

## Checklist before requesting a review:
- [x] I have run the game locally
- [x] I have performed self-review on my code
- [x] I have confirmed critical features still function
