### PR TITLE
FOX-251: Score handling for levels with no timer

### DIFF
--- a/Assets/Scenes/Final levels/Level 0.unity
+++ b/Assets/Scenes/Final levels/Level 0.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.18028326, g: 0.22571333, b: 0.30692202, a: 1}
+  m_IndirectSpecularColor: {r: 0.18028378, g: 0.22571412, b: 0.30692285, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -10439,7 +10439,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &641758764
 RectTransform:
   m_ObjectHideFlags: 0
@@ -29122,6 +29122,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Name
       value: Speedrun Timer
+      objectReference: {fileID: 0}
+    - target: {fileID: 899666648612439573, guid: 62a04f33bea3d874688ef6887830d745,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1027479900984394065, guid: 62a04f33bea3d874688ef6887830d745,
         type: 3}

--- a/Assets/Scripts/LevelEnd.cs
+++ b/Assets/Scripts/LevelEnd.cs
@@ -1,5 +1,4 @@
 using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 
@@ -15,11 +14,17 @@ public class LevelEnd : MonoBehaviour
     private bool m_levelEnded;
     private GrowAndShrinkLevelEndGlow m_GrowShrinkScript;
 
+    private bool m_isCountedInSpeedrun;
+
     private void Awake()
     {
         m_HoleTransition = GameObject.Find("HoleTransition").GetComponent<CloseOrOpenCircle>();
-        m_GameTimer = GameObject.Find("Speedrun Timer").GetComponent<GameTimer>();
         m_GrowShrinkScript = GetComponentInChildren<GrowAndShrinkLevelEndGlow>();
+
+        // Determines whether the current level has a timer and therefore will be counted as part of the speedrun
+        GameObject gameTimerObject = GameObject.Find("Speedrun Timer");
+        m_isCountedInSpeedrun = gameTimerObject ?? false;
+        m_GameTimer = m_isCountedInSpeedrun ? gameTimerObject.GetComponent<GameTimer>() : null;
     }
 
     private void OnTriggerEnter2D(Collider2D collision)
@@ -40,7 +45,10 @@ public class LevelEnd : MonoBehaviour
 
             // Call the TimerAction method after the specified delay
             StartCoroutine(EndDelayEnded());
-            SaveUtils.RecordTime(m_GameTimer.TimeElapsed);
+            if (m_isCountedInSpeedrun)
+            {
+                SaveUtils.RecordTime(m_GameTimer.TimeElapsed);
+            }
             PlayerPrefs.SetInt("LastScene", SceneManager.GetActiveScene().buildIndex);
         }
     }

--- a/Assets/Scripts/UI/Timer/GameTimer.cs
+++ b/Assets/Scripts/UI/Timer/GameTimer.cs
@@ -15,9 +15,6 @@ public class GameTimer : MonoBehaviour
     {
         ResetTimer();
         StartTimer();
-
-        //SaveUtils.InitializeProfile(); // Only meant for testing, to be deleted
-        //CsvUtils.WriteToFile(SaveUtils.GetPlayerData());
     }
 
     private void Update()
@@ -43,7 +40,6 @@ public class GameTimer : MonoBehaviour
     }
 
     // Pause timer, can be assigned to the GameEnd event (when it's implemented), and game pause
-    // NOTE: Scoreboard related implementation should not be here (comment to be deleted after scoreboard implementation)
     public void PauseTimer()
     {
         m_TimerIsRunning = false;


### PR DESCRIPTION
**Test scene (if any):**
- `Scenes/Final levels/Level 0.unity`

## Changes summary:
- If a level doesn't have a timer, then completing that level won't count towards the final time of the speedrun

## Checklist before requesting a review:
- [x] I have run the game locally
- [x] I have performed self-review on my code
- [x] I have confirmed critical features still function
