### PR TITLE
FOX-340-BUG-fix-circle-transition-opening

### DIFF
--- a/Assets/Scripts/UI/CloseOrOpenCircle.cs
+++ b/Assets/Scripts/UI/CloseOrOpenCircle.cs
@@ -77,6 +77,7 @@ public class CloseOrOpenCircle : MonoBehaviour
     {
         SetScales();
         yield return null;  //This line makes Unity wait til the next frame to continue the execution. Basically this is to prevent a hitch when doing the transition. All the objects in the scene will do their Start() code, THEN this one can start it's transition instead of starting it, letting everything else go, then continuing.
+        yield return null;  //Ok needed ONE more frame to fix the stutter in the animation
         StartCoroutine(GrowParentObject());
     }
 


### PR DESCRIPTION
**Test scene (if any):**
- any final level

## Changes summary:
- added an additional 1 frame delay before it starts to eliminate the broken opening transition (I think some other objects onStart were hitching it so the 1 frame delay is needed (and unnoticeable))

## Checklist before requesting a review:
- [x] I have run the game locally
- [x] I have performed self-review on my code
- [x] I have confirmed critical features still function
